### PR TITLE
Fix jarjar.bzl to handle RBE execution

### DIFF
--- a/tools/jarjar/jarjar.bzl
+++ b/tools/jarjar/jarjar.bzl
@@ -15,8 +15,9 @@
 """
 
 def _jarjar_library(ctx):
+    _rules_file = ctx.actions.declare_file('jarjar.rules')
     ctx.actions.write(
-        output = ctx.outputs._rules_file,
+        output = _rules_file,
         content = "\n".join(ctx.attr.rules),
     )
 
@@ -58,7 +59,7 @@ def _jarjar_library(ctx):
         jars = " ".join([jar.path for jar in jar_files]),
         java_home = str(ctx.attr._jdk[java_common.JavaRuntimeInfo].java_home),
         jarjar = ctx.executable._jarjar.path,
-        rules_file = ctx.outputs._rules_file.path,
+        rules_file = _rules_file.path,
         outfile = ctx.outputs.jar.path,
     )
 
@@ -66,10 +67,12 @@ def _jarjar_library(ctx):
         command = command,
         inputs = [
             ctx.executable._jarjar,
-            ctx.outputs._rules_file,
+            _rules_file,
         ] + jar_files + ctx.files._jdk,
         outputs = [ctx.outputs.jar],
     )
+
+    return [JavaInfo(ctx.outputs.jar, ctx.outputs.jar)]
 
 jarjar_library = rule(
     attrs = {
@@ -89,7 +92,6 @@ jarjar_library = rule(
     },
     outputs = {
         "jar": "%{name}.jar",
-        "_rules_file": "%{name}.jarjar_rules",
     },
     implementation = _jarjar_library,
 )

--- a/tools/jarjar/jarjar.bzl
+++ b/tools/jarjar/jarjar.bzl
@@ -72,13 +72,19 @@ def _jarjar_library(ctx):
         outputs = [ctx.outputs.jar],
     )
 
-    return [JavaInfo(ctx.outputs.jar, ctx.outputs.jar)]
+    return [JavaInfo(
+        output_jar=ctx.outputs.jar,
+        compile_jar=ctx.outputs.jar,
+        deps=[x[JavaInfo] for x in ctx.attr.deps])]
 
 jarjar_library = rule(
     attrs = {
         "rules": attr.string_list(),
         "jars": attr.label_list(
             allow_files = [".jar"],
+        ),
+        "deps": attr.label_list(
+            providers = [JavaInfo]
         ),
         "_jarjar": attr.label(
             default = Label("//tools/jarjar"),


### PR DESCRIPTION
The `jarjar.bzl` script assumes that the value of `{java_home}` is always relative, (eg. `external/local_jdk`) and therefore it needs to be used in conjunction with `pwd` in order to get the full path to Java's location. See the following line taken from [jarjar.bzl @ master](https://github.com/google/bazel-common/blob/master/tools/jarjar/jarjar.bzl#L26):
```
JAVA_HOME=$(pwd)/{java_home} # this is used outside of the root
```

This works in most cases, however, we've encountered a scenario where it may be an absolute path, such as when you want to specify your own toolchain for Remote Build Execution.

This issue hits us when we're trying to run a test on Google Cloud's Remote Build Execution. The test will fail with the following error:
```
$ bazel --bazelrc=.bazelrc test //server/test/server/deduplicator:rocks-db-queue-test --config=remote --remote_instance_name=projects/<our-rbe-project-id>/instances/default_instance --project_id=<our-rbe-project-id> --verbose_failures
INFO: Invocation ID: abae541f-e00d-4122-8849-769bffaa40fb
DEBUG: /root/.cache/bazel/_bazel_root/8a4e683c96774f55a46951715144dd49/external/bazel_skylib/lib.bzl:30:1: WARNING: lib.bzl is deprecated and will go away in the future, please directly load the bzl file(s) of the module(s) needed as it is more efficient.
INFO: Analysed target //server/test/server/deduplicator:rocks-db-queue-test (0 packages loaded, 0 targets configured).
INFO: Found 1 test target...
INFO: From SkylarkAction graql/java/graql.jar:
/bin/bash: line 26: /b/f/w//usr/lib/jvm/java-8-openjdk-amd64/bin/jar: No such file or directory
Exception in thread "main" java.io.FileNotFoundException: /tmp/tmp.GeHanqPjjd/combined.jar (No such file or directory)
	at java.util.zip.ZipFile.open(Native Method)
	at java.util.zip.ZipFile.<init>(ZipFile.java:225)
	at java.util.zip.ZipFile.<init>(ZipFile.java:155)
	at java.util.jar.JarFile.<init>(JarFile.java:166)
	at java.util.jar.JarFile.<init>(JarFile.java:130)
	at org.pantsbuild.jarjar.util.StandaloneJarProcessor.run(StandaloneJarProcessor.java:31)
	at org.pantsbuild.jarjar.Main.process(Main.java:95)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.pantsbuild.jarjar.MainUtil.runMain(MainUtil.java:37)
	at org.pantsbuild.jarjar.Main.main(Main.java:50)
ERROR: /grakn/graql/java/BUILD:23:1: output 'graql/java/graql.jar' was not created
ERROR: /grakn/graql/java/BUILD:23:1: not all outputs were created or valid
Target //server/test/server/deduplicator:rocks-db-queue-test failed to build
INFO: Elapsed time: 6.395s, Critical Path: 3.94s
INFO: 17 processes: 17 remote cache hit.
FAILED: Build did NOT complete successfully

FAILED: Build did NOT complete successfully
```
As you can see, `JAVA_HOME` is now pointing to an incorrect location `/b/f/w//usr/lib/jvm/java-8-openjdk-amd64/bin/jar`. It should be pointing to `/usr/lib/jvm/java-8-openjdk-amd64/bin/jar` instead. 

This can be fixed by handling both absolute and relative path scenario, see my follow up PR https://github.com/google/bazel-common/pull/44.